### PR TITLE
Blank "name" and "groups" are not allowed in admin

### DIFF
--- a/its_on/admin/schemes.py
+++ b/its_on/admin/schemes.py
@@ -26,14 +26,14 @@ class BaseSwitchAdminPostRequestSchema(Schema):
 
 class SwitchDetailAdminPostRequestSchema(BaseSwitchAdminPostRequestSchema):
     groups = SplitList(
-        fields.Str(), validate=validate.Length(min=1, error='At least one group is required.')
+        fields.Str(), validate=validate.Length(min=1, error='At least one group is required.'),
     )
 
 
 class SwitchAddAdminPostRequestSchema(BaseSwitchAdminPostRequestSchema):
     name = fields.Str(validate=validate.Length(min=1, error='Empty name is not allowed.'))
     groups = SplitList(
-        fields.Str(), validate=validate.Length(min=1, error='At least one group is required.')
+        fields.Str(), validate=validate.Length(min=1, error='At least one group is required.'),
     )
 
 

--- a/its_on/admin/schemes.py
+++ b/its_on/admin/schemes.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import typing
-from marshmallow import Schema, fields
+
+from marshmallow import Schema, fields, validate
 
 
 class SplitList(fields.List):
@@ -24,12 +25,16 @@ class BaseSwitchAdminPostRequestSchema(Schema):
 
 
 class SwitchDetailAdminPostRequestSchema(BaseSwitchAdminPostRequestSchema):
-    groups = SplitList(fields.Str())
+    groups = SplitList(
+        fields.Str(), validate=validate.Length(min=1, error='At least one group is required.')
+    )
 
 
 class SwitchAddAdminPostRequestSchema(BaseSwitchAdminPostRequestSchema):
-    name = fields.Str()
-    groups = SplitList(fields.Str())
+    name = fields.Str(validate=validate.Length(min=1, error='Empty name is not allowed.'))
+    groups = SplitList(
+        fields.Str(), validate=validate.Length(min=1, error='At least one group is required.')
+    )
 
 
 class SwitchAddFromAnotherItsOnAdminPostRequestSchema(BaseSwitchAdminPostRequestSchema):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,13 @@ async def client(aiohttp_client: Callable) -> None:
 
 
 @pytest.fixture()
-async def switch(client):
-    async with client.server.app['db'].acquire() as conn:
+def db_conn_acquirer(client) -> Callable:
+    return client.server.app['db'].acquire
+
+
+@pytest.fixture()
+async def switch(db_conn_acquirer):
+    async with db_conn_acquirer() as conn:
         result = await conn.execute(switches.select().where(switches.c.id == 1))
         return await result.first()
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -77,7 +77,7 @@ async def test_switch_add(setup_tables_and_data, client, login, switch):
 
 async def test_switch_update(setup_tables_and_data, client, login, switch):
     with freeze_time('2020-08-15'):
-        await client.post('/zbs/switches/1', data={'is_active': False})
+        await client.post('/zbs/switches/1', data={'is_active': False, 'groups': 'group1, group2'})
 
     async with client.server.app['db'].acquire() as conn:
         switches_query_result = await conn.execute(switches.select().where(switches.c.id == 1))

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -7,24 +7,30 @@ from auth.models import users
 from its_on.models import switch_history, switches
 
 
-async def test_switches_list_without_auhtorize(setup_tables_and_data, client):
+@pytest.mark.usefixtures('setup_tables_and_data')
+async def test_switches_list_without_auhtorize(client):
     response = await client.get('/zbs/switches')
 
     assert response.status == 401
 
 
-async def test_update_switch_without_login(setup_tables_and_data, client):
+@pytest.mark.usefixtures('setup_tables_and_data')
+async def test_update_switch_without_login(client):
     response = await client.post('/zbs/switches/1', data={'version': 'some_shit'})
 
     assert response.status == 401
 
 
-@pytest.mark.parametrize('switch_title, expected_result', [
-    ('switch1', True),
-    ('switch2', True),
-    ('switch1488', False),
-])
-async def test_switches_list(setup_tables_and_data, client, login, switch_title, expected_result):
+@pytest.mark.parametrize(
+    'switch_title, expected_result',
+    [
+        ('switch1', True),
+        ('switch2', True),
+        ('switch1488', False),
+    ],
+)
+@pytest.mark.usefixtures('setup_tables_and_data', 'login')
+async def test_switches_list(client, switch_title, expected_result):
     response = await client.get('/zbs/switches')
 
     content = await response.content.read()
@@ -32,7 +38,8 @@ async def test_switches_list(setup_tables_and_data, client, login, switch_title,
     assert (switch_title in content.decode('utf-8')) is expected_result
 
 
-async def test_switch_detail(setup_tables_and_data, client, login, switch):
+@pytest.mark.usefixtures('setup_tables_and_data', 'login')
+async def test_switch_detail(client, switch):
     response = await client.get('/zbs/switches/1')
 
     content = await response.content.read()
@@ -40,46 +47,72 @@ async def test_switch_detail(setup_tables_and_data, client, login, switch):
     assert switch.name in content.decode('utf-8')
 
 
-@freeze_time(datetime.datetime(2020, 4, 15, tzinfo=datetime.timezone.utc))
-async def test_switch_add(setup_tables_and_data, client, login, switch):
+@pytest.mark.usefixtures('setup_tables_and_data', 'login')
+async def test_switch_add_get_method(client):
     response = await client.get('/zbs/switches/add')
     content = await response.content.read()
 
     assert 'Flag adding' in content.decode('utf-8')
 
+
+@freeze_time(datetime.datetime(2020, 4, 15, tzinfo=datetime.timezone.utc))
+@pytest.mark.usefixtures('setup_tables_and_data')
+async def test_switch_add_post_method(client, db_conn_acquirer, login):
     switch_data = {
         'name': 'switch_to_check_add',
         'is_active': True,
         'groups': 'check_adding, group2,    ,,',
         'version': 1,
-        'comment': 'This is the story of a big bad wolf an little girl whose name was Little Red Riding Hood',
+        'comment': 'This is the story of a big bad wolf an little girl whose name was...',
     }
+
     response = await client.post('/zbs/switches/add', data=switch_data)
     content = await response.content.read()
-
-    assert 'Switches list' in content.decode('utf-8')
-
     switch_data['is_hidden'] = False
 
-    async with client.server.app['db'].acquire() as conn:
+    assert 'Switches list' in content.decode('utf-8')
+    async with db_conn_acquirer() as conn:
         result = await conn.execute(switches.select().where(switches.c.name == switch_data['name']))
         created_switch = await result.first()
-
     for field_name, field_value in switch_data.items():
         if field_name == 'groups':
-            field_value = list(
-                filter(None, [item.strip() for item in field_value.split(',')]),
-            )
+            field_value = ['check_adding', 'group2']
         assert getattr(created_switch, field_name) == field_value
-
     assert created_switch.created_at == datetime.datetime(2020, 4, 15, tzinfo=datetime.timezone.utc)
 
 
-async def test_switch_update(setup_tables_and_data, client, login, switch):
+@pytest.mark.parametrize(
+    ('blank_field', 'error_message'),
+    [
+        ('name', 'Empty name is not allowed.'),
+        ('groups', 'At least one group is required.'),
+    ],
+)
+@pytest.mark.usefixtures('setup_tables_and_data')
+async def test_switch_add_blank_fields_not_allowed(blank_field, error_message, client, login):
+    switch_data = {
+        'name': 'switch-1337',
+        'is_active': True,
+        'groups': 'group',
+        'version': 1,
+        'comment': 'Hi!',
+        blank_field: '',
+    }
+
+    response = await client.post('/zbs/switches/add', data=switch_data)
+    content = await response.content.read()
+    content_decoded = content.decode('utf-8')
+
+    assert 'Flag adding' in content_decoded
+    assert error_message in content_decoded
+
+
+@pytest.mark.usefixtures('setup_tables_and_data')
+async def test_switch_update(client, login, switch, db_conn_acquirer):
     with freeze_time('2020-08-15'):
         await client.post('/zbs/switches/1', data={'is_active': False, 'groups': 'group1, group2'})
 
-    async with client.server.app['db'].acquire() as conn:
+    async with db_conn_acquirer() as conn:
         switches_query_result = await conn.execute(switches.select().where(switches.c.id == 1))
         updated_switch = await switches_query_result.first()
         switch_history_query_result = await conn.execute(
@@ -100,28 +133,27 @@ async def test_switch_update(setup_tables_and_data, client, login, switch):
     )
 
 
-async def test_switch_soft_delete(setup_tables_and_data, client, login, switch):
+@pytest.mark.usefixtures('setup_tables_and_data')
+async def test_switch_soft_delete(client, login, switch):
     response = await client.get('/zbs/switches')
     content = await response.content.read()
-
     assert 'switch7' in content.decode('utf-8')
 
     await client.get('/zbs/switches/7/delete')
-
     response = await client.get('/zbs/switches')
     content = await response.content.read()
 
     assert 'switch7' not in content.decode('utf-8')
 
 
-async def test_resurrect_switch(setup_tables_and_data, client, login, switch):
+@pytest.mark.usefixtures('setup_tables_and_data')
+async def test_resurrect_switch(client, login, switch):
     response = await client.get('/zbs/switches')
     content = await response.content.read()
 
     assert 'switch3' in content.decode('utf-8')
 
     await client.get('/zbs/switches/3/delete')
-
     response = await client.get('/zbs/switches')
     content = await response.content.read()
 
@@ -147,23 +179,30 @@ async def test_switches_copy_without_auhtorize(setup_tables_and_data, client):
 
 
 @pytest.mark.parametrize(
-    ('http_get_arguments', 'old_switch_is_active_expected', 'expected_updated_at'), [
+    ('http_get_arguments', 'old_switch_is_active_expected', 'expected_updated_at'),
+    [
         ('', True, datetime.datetime(2020, 4, 15, tzinfo=datetime.timezone.utc)),
-        ('?update_existing=true', False, datetime.datetime(2020, 10, 15, tzinfo=datetime.timezone.utc)),
+        (
+            '?update_existing=true',
+            False,
+            datetime.datetime(2020, 10, 15, tzinfo=datetime.timezone.utc),
+        ),
     ],
 )
 @freeze_time(datetime.datetime(2020, 10, 15, tzinfo=datetime.timezone.utc))
-@pytest.mark.usefixtures('setup_tables_and_data', 'get_switches_data_mocked_existing_switch')
+@pytest.mark.usefixtures('setup_tables_and_data', 'login', 'get_switches_data_mocked_existing_switch')
 async def test_switches_copy_existing_switch_foo(
-    client, login,
-    http_get_arguments, old_switch_is_active_expected, expected_updated_at,
+    client,
+    db_conn_acquirer,
+    http_get_arguments,
+    old_switch_is_active_expected,
+    expected_updated_at,
 ):
     response = await client.post(f'/zbs/switches/copy{http_get_arguments}')
-    async with client.server.app['db'].acquire() as conn:
+    async with db_conn_acquirer() as conn:
         result = await conn.execute(switches.count())
         switches_count = await result.first()
         switches_count = switches_count[0]
-
         result = await conn.execute(switches.select().where(switches.c.name == 'switch7'))
         old_switch = await result.first()
 
@@ -173,12 +212,13 @@ async def test_switches_copy_existing_switch_foo(
     assert old_switch.updated_at == expected_updated_at
 
 
-@pytest.mark.usefixtures('setup_tables_and_data', 'get_switches_data_mocked_new_switch')
-async def test_switches_copy_new_switch(client, login):
+@pytest.mark.usefixtures('setup_tables_and_data', 'login', 'get_switches_data_mocked_new_switch')
+async def test_switches_copy_new_switch(client, db_conn_acquirer):
     response = await client.post('/zbs/switches/copy')
-    async with client.server.app['db'].acquire() as conn:
+    async with db_conn_acquirer() as conn:
         result = await conn.execute(
-            switches.select().where(switches.c.name == 'extremely_new_switch'))
+            switches.select().where(switches.c.name == 'extremely_new_switch'),
+        )
         new_switch = await result.first()
 
     assert response.status == 200


### PR DESCRIPTION
Switch's Name and Groups fields cannot be blank
Admin test refactoring