### PR TITLE
release: 0.1.1

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,8 +1,0 @@
-version: "2"
-checks:
-  file-lines:
-    config:
-      threshold: 500
-  complex-logic:
-    config:
-      threshold: 8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,21 +55,3 @@ jobs:
           dockerfile: Dockerfile
       - name: Run checks
         run: make check
-      - name: Run tests with coverage and upload to Code Climate
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        run: |
-          if [ -z "${CC_TEST_REPORTER_ID:-}" ]; then
-            echo "CC_TEST_REPORTER_ID is not set; skipping Code Climate coverage upload"
-            exit 0
-          fi
-          set -euo pipefail
-          curl -Ls https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 -o cc-test-reporter
-          chmod +x cc-test-reporter
-          ./cc-test-reporter before-build
-          set +e
-          make coverage
-          code=$?
-          set -e
-          ./cc-test-reporter after-build --coverage-input-type coverage.py --exit-code "$code"
-          exit "$code"

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 env:
   DYNACONF_REDIS_URL: redis://localhost:6379/1
   DYNACONF_CACHE_URL: redis://localhost:6379/1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Set release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Log in to Docker Hub
@@ -73,6 +75,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             bestdoctor/its_on:latest
             bestdoctor/its_on:${{ env.RELEASE_VERSION }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # It's on
 
 [![Build Status](https://github.com/best-doctor/its_on/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/best-doctor/its_on/actions/workflows/build.yml)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/35e678c4d05199a31eb9/test_coverage)](https://codeclimate.com/github/best-doctor/its_on/test_coverage)
 
 Flag/feature toggle service, written in aiohttp.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "its_on"
-version = "0.1.0"
+version = "0.1.1"
 description = "Flag/feature toggle service, written in aiohttp."
 authors = [
     {name = "Luchi Insurance JSC", email = "info@luchi.ru"},


### PR DESCRIPTION
CI: GitHub Actions — checkout/setup-python v6; publish — Buildx, docker/login и build-push актуальных major; Python 3.11 и те же проверки, что на master; удалены Code Climate (.codeclimate.yml, загрузка отчётов) и Codecov; в README убраны бейджи покрытия.
Made-with: Cursor