### PR TITLE
fix(alembic): add repo root to sys.path before importing its_on

### DIFF
--- a/db/migrations/env.py
+++ b/db/migrations/env.py
@@ -1,15 +1,17 @@
 import os
-from logging.config import fileConfig
 import sys
+from logging.config import fileConfig
 
-from its_on.config import settings
+from alembic import context
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 
-from alembic import context
+# Repo root must be on sys.path before project imports (order matters; do not rely on cwd).
+_repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
 
-parent_dir = os.path.abspath(os.path.join(os.getcwd()))
-sys.path.append(parent_dir)
+from its_on.config import settings
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "its_on"
-version = "0.1.2"
+version = "0.1.3"
 description = "Flag/feature toggle service, written in aiohttp."
 authors = [
     {name = "Luchi Insurance JSC", email = "info@luchi.ru"},


### PR DESCRIPTION
env.py imported settings before mutating sys.path, so ModuleNotFoundError always occurred. Resolve repo root from __file__ and insert it first.

Made-with: Cursor